### PR TITLE
Updates v0.0.19

### DIFF
--- a/examples/group/src/index.ts
+++ b/examples/group/src/index.ts
@@ -39,7 +39,6 @@ const commandHandlers: CommandHandlers = {
     const intro =
       "Decentralized secure messaging. Built for crypto.\n" +
       "Welcome to the Apps Directory\n\n" +
-      "- 🎰 betbot.eth : Create bets with your friends.\n\n\n" +
       "- 💧 faucetbot.eth : Delivers Faucet funds to devs on Testnet\n\n\n" +
       "- 🛍️ thegeneralstore.eth : Simple ecommerce storefront for hackathon goods\n\n\n" +
       "- 📅 wordlebot.eth : Play daily to the WORDLE game through messaging.\n\n\n" +

--- a/examples/group/src/index.ts
+++ b/examples/group/src/index.ts
@@ -54,8 +54,6 @@ const commandHandlers: CommandHandlers = {
 const appConfig = {
   commands: commands,
   commandHandlers: commandHandlers,
-  privateKey:
-    "0x39125352f9ebad5ee1bd2a84de9351e6b7687416aa0b71b72697fc86ba9f88c9",
 };
 
 // Main function to run the app

--- a/examples/group/src/index.ts
+++ b/examples/group/src/index.ts
@@ -32,7 +32,6 @@ const commandHandlers: CommandHandlers = {
         .map((command) => `${command.command} - ${command.description}`)
         .join("\n") +
       "\nUse these commands to interact with specific apps.";
-    console.log(context.send);
     context.send(intro);
   },
   "/apps": async (context: HandlerContext) => {
@@ -55,6 +54,8 @@ const commandHandlers: CommandHandlers = {
 const appConfig = {
   commands: commands,
   commandHandlers: commandHandlers,
+  privateKey:
+    "0x39125352f9ebad5ee1bd2a84de9351e6b7687416aa0b71b72697fc86ba9f88c9",
 };
 
 // Main function to run the app

--- a/packages/docs/pages/concepts/messages/group-update.mdx
+++ b/packages/docs/pages/concepts/messages/group-update.mdx
@@ -6,6 +6,22 @@ Join Converse Beta to experience groups. [Learn more](https://paragraph.xyz/@eph
 
 > For more details, see XMTP's [Groups documentation](https://docs.xmtp.org/groups/build-group-chat).
 
+## Added to a group
+
+When a user is added to a group it will emit a `new_group` event.
+
+```tsx
+const {
+  message: { typeId, sender },
+  group,
+} = context;
+
+if (typeId == "new_group") {
+  // handle being added to a group
+  return;
+}
+```
+
 ## Group updated object
 
 The `group_updated` type contains the following

--- a/packages/docs/pages/use-cases/group/index.mdx
+++ b/packages/docs/pages/use-cases/group/index.mdx
@@ -300,11 +300,10 @@ const commandHandlers: CommandHandlers = {
     const intro =
       "Decentralized secure messaging. Built for crypto.\n" +
       "Welcome to the Apps Directory\n\n" +
-      "- 🎰 betbot.eth : Create bets with your friends.\n\n\n" +
       "- 💧 faucetbot.eth : Delivers Faucet funds to devs on Testnet\n\n\n" +
       "- 🛍️ thegeneralstore.eth : Simple ecommerce storefront for hackathon goods\n\n\n" +
       "- 📅 wordlebot.eth : Play daily to the WORDLE game through messaging.\n\n\n" +
-      "- 🪨 mintframe - 0xB7d51dD8331551D2FA0d185F8Ba08DcCd71499aD : Turn a Zora url into a mint frame.\n\n\n" +
+      "- 🪨 urltomint.eth : Turn a Zora url into a mint frame.\n\n\n" +
       "To learn how to build your own app, visit MessageKit: https://message-kit.vercel.app/\n\n" +
       "To publish your app, visit Directory: https://message-kit.vercel.app/directory\n\n" +
       "You are currently inside Message Kit Group Starter. You can type:\n/help command to see available commands\n/apps to trigger the directory.";

--- a/packages/docs/pages/use-cases/group/tipping.mdx
+++ b/packages/docs/pages/use-cases/group/tipping.mdx
@@ -2,7 +2,7 @@
 
 In this example you can tip using 3 primitives:
 
-- Emoji reaction `emoji:🎩`
+- Emoji reaction `🎩`
 - Text message starting with `/tip @bo 10 degen`
 - Reply `10 $degen`
 

--- a/packages/message-kit/package.json
+++ b/packages/message-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/message-kit",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/message-kit/package.json
+++ b/packages/message-kit/package.json
@@ -23,7 +23,7 @@
     "format": "yarn format:base -w .",
     "format:base": "prettier --ignore-path ../../.gitignore",
     "format:check": "yarn format:base -c .",
-    "prepublishOnly": "yarn build",
+    "prepublishOnly": " cd ../../ && yarn copy && yarn build",
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/message-kit/package.json
+++ b/packages/message-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/message-kit",
-  "version": "0.0.16",
+  "version": "0.0.18",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/message-kit/src/lib/client.ts
+++ b/packages/message-kit/src/lib/client.ts
@@ -19,12 +19,9 @@ export default async function xmtpClient(
   privateKey: string | null = null,
 ): Promise<{ client: Client; v2client: V2Client }> {
   let key = privateKey ?? process.env.KEY;
-  if (!key || !isHex(key)) {
+  if (!isHex(key)) {
     key = generatePrivateKey();
-    console.error(
-      "KEY not set. Using random one. For using your own wallet , set the KEY environment variable.",
-    );
-    console.log("Random private key: ", key);
+    console.error(".env KEY not set. Using random one:\n", key);
   }
 
   const account = privateKeyToAccount(key as `0x${string}`);

--- a/packages/message-kit/src/lib/handlerContext.ts
+++ b/packages/message-kit/src/lib/handlerContext.ts
@@ -93,23 +93,15 @@ export default class HandlerContext {
       typeof message.content === "string"
         ? message.content.trim()
         : message.content;
-
     if (message.contentType.sameAs(ContentTypeText)) {
-      content = parseCommand(
-        message?.content,
-        commands ?? [],
-        context.members ?? [],
-      );
+      content = parseCommand(content, commands ?? [], context.members ?? []);
     } else if (message.contentType.sameAs(ContentTypeReply)) {
       content = {
         ...content,
         typeId: message.content.contentType.typeId,
       };
     } else if (message.contentType.sameAs(ContentTypeRemoteAttachment)) {
-      const attachment = await RemoteAttachmentCodec.load(
-        message.content,
-        client,
-      );
+      const attachment = await RemoteAttachmentCodec.load(content, client);
       content = {
         ...content,
         attachment: attachment,
@@ -128,6 +120,15 @@ export default class HandlerContext {
       typeId: message.contentType.typeId,
       sent: sentAt,
     };
+
+    if (process?.env?.MSG_LOG) {
+      //trim spaces from text
+      let content =
+        typeof message?.content === "string"
+          ? message?.content
+          : message?.contentType.typeId;
+      console.log(`incoming_${version}:`, content, senderAddress);
+    }
 
     return context;
   }

--- a/packages/message-kit/src/lib/handlerContext.ts
+++ b/packages/message-kit/src/lib/handlerContext.ts
@@ -129,6 +129,7 @@ export default class HandlerContext {
           typeof message?.content === "string"
             ? message?.content
             : message?.contentType.typeId;
+
         console.log("content", content, senderAddress);
       }
 

--- a/packages/message-kit/src/lib/handlerContext.ts
+++ b/packages/message-kit/src/lib/handlerContext.ts
@@ -216,6 +216,7 @@ export default class HandlerContext {
           send: this.send.bind(this),
           sendTo: this.sendTo.bind(this),
           react: this.react.bind(this),
+          isGroup: this.group instanceof Conversation,
         };
         const handler =
           this.commandHandlers?.[

--- a/packages/message-kit/src/lib/handlerContext.ts
+++ b/packages/message-kit/src/lib/handlerContext.ts
@@ -37,7 +37,6 @@ export default class HandlerContext {
 
   private constructor(
     conversation: Conversation | ConversationV2,
-    message: DecodedMessage | DecodedMessageV2,
     { client, v2client }: { client: Client; v2client: ClientV2 },
     commands?: CommandGroup[],
     commandHandlers?: CommandHandlers,
@@ -66,7 +65,6 @@ export default class HandlerContext {
   ): Promise<HandlerContext> {
     const context = new HandlerContext(
       conversation,
-      message,
       { client, v2client },
       commands,
       commandHandlers,
@@ -90,7 +88,12 @@ export default class HandlerContext {
       client.conversations?.getMessageById?.bind(client.conversations) ||
       (() => null);
 
-    let content = message.content;
+    //trim spaces from text
+    let content =
+      typeof message.content === "string"
+        ? message.content.trim()
+        : message.content;
+
     if (message.contentType.sameAs(ContentTypeText)) {
       content = parseCommand(
         message?.content,

--- a/packages/message-kit/src/lib/handlerContext.ts
+++ b/packages/message-kit/src/lib/handlerContext.ts
@@ -129,7 +129,7 @@ export default class HandlerContext {
           typeof message?.content === "string"
             ? message?.content
             : message?.contentType.typeId;
-        console.log(`incoming_${version}:`, content, senderAddress);
+        console.log("content", content, senderAddress);
       }
 
       return context;
@@ -143,7 +143,7 @@ export default class HandlerContext {
           username: "",
           accountAddresses: [],
         },
-        typeId: "conversation",
+        typeId: "new_" + (context.isGroup ? "group" : "conversation"),
         sent: conversation.createdAt,
       };
     }

--- a/packages/message-kit/src/lib/runner.ts
+++ b/packages/message-kit/src/lib/runner.ts
@@ -23,6 +23,13 @@ export default async function run(handler: Handler, config?: Config) {
     message: any,
   ) => {
     if (message) {
+      if (process?.env?.ISSUE_LOG) {
+        let content =
+          typeof message?.content === "string"
+            ? message?.content
+            : message?.contentType.typeId;
+        console.log(`stream:`, content, message?.conversationId);
+      }
       try {
         const { senderInboxId, senderAddress } = message;
         let conversation;
@@ -44,9 +51,6 @@ export default async function run(handler: Handler, config?: Config) {
           return;
         }
 
-        if (process?.env?.MSG_LOG) {
-          console.log(`incoming_${version}:`, message.content);
-        }
         const context = await HandlerContext.create(
           conversation,
           message,


### PR DESCRIPTION
#### Added conversation streams
- Reason: To enable the bot to send a welcome message when a new group is created.
#### Trim messages
- Reason: Commands with a space before (e.g., " /help") were not recognized. Now, messages are trimmed by default to remove spaces before and after.
#### Fixed privateKey bug
- Reason: Handling 5 different bots for ENS in parallel within the same bot. Fixed a bug related to sending the private key parameter.
####  Added `new_group` event and documentation improvements
- Reason: Documented a new section about being added to a new group and made overall documentation improvements.
#### `getReplyChain`
- reason: The `getReplyChain` method retrieves a chain of messages that are replies to each other. It starts with a reference message and follows the chain of replies back to the original message. 