### PR TITLE
Fix Plausible domain

### DIFF
--- a/packages/docs/vocs.config.tsx
+++ b/packages/docs/vocs.config.tsx
@@ -6,8 +6,8 @@ export default defineConfig({
     return (
       <>
         <script
-          src="https://plausible.io/js/script.js"
-          data-domain="docs.xmtp.org"
+          src="https://plausible.io/js/script.outbound-links.js"
+          data-domain="messagekit.ephemerahq.com"
           defer
         />
       </>


### PR DESCRIPTION
In troubleshooting the Plausible script, I left in the docs.xmtp.org domain. 🤦🏻‍♀️ 

Also updated the script to report on outbound link clicks.

Once this PR is merged, Plausible will start working for the MessageKit docs.