### PR TITLE
Add redirect in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "redirects": [
+    {
+      "source": "/(.*)",
+      "destination": "https://messagekit.ephemerahq.com/$1",
+      "permanent": true,
+      "has": [
+        { "type": "host", "value": "message-kit.vercel.app" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Currently, when we merge a PR authored by someone other than @fabriguespe, the production site displays a 404: NOT_FOUND error.

From talking with ChatGPT, it sounds like moving the redirect of `message-kit.vercel.app` to `messagekit.ephemerahq.com` from the Vercel UI to a `vercel.json` in the repo might help apply the redirect more consistently regardless of the PR author.

Shall we try this?

1. Merge this PR.
2. Remove the redirect from the Vercel UI.
3. J-Ha author a PR.
4. Fabri approve and merge the PR.
5. Check if the production site is working.