### PR TITLE
Message Kit Documentation Fixes Changes Made

### DIFF
--- a/packages/docs/pages/middlewares/gpt.mdx
+++ b/packages/docs/pages/middlewares/gpt.mdx
@@ -2,7 +2,7 @@
 
 This middleware is used to generate responses using OpenAI.
 
-> Already commes with message-kit.
+> Already comes with message-kit.
 
 ```tsx [src/lib/gpt.ts]
 import "dotenv/config";
@@ -54,7 +54,7 @@ export const PROMPT_RULES = `You are a helpful and playful agent called {NAME} t
 - You can respond with multiple messages if needed. Each message should be separated by a newline character.
 - You can trigger skills by only sending the command in a newline message.
 - Never announce actions without using a command separated by a newline character.
-- Dont answer in markdown format, just answer in plaintext.
+- Don't answer in markdown format, just answer in plaintext.
 - Do not make guesses or assumptions
 - Only answer if the verified information is in the prompt.
 - Check that you are not missing a command

--- a/packages/docs/pages/skills/parsing.mdx
+++ b/packages/docs/pages/skills/parsing.mdx
@@ -1,6 +1,6 @@
 # Parsing
 
-Parsing enables your agent to understand human-like requests and translate them into precise skill with defined parameters that can be used by the handler.
+Parsing enables your agent to understand human-like requests and translate them into precise skills with defined parameters that can be used by the handler.
 
 ## Overview
 

--- a/packages/docs/pages/templates/agent/prompt.mdx
+++ b/packages/docs/pages/templates/agent/prompt.mdx
@@ -31,7 +31,7 @@ export async function agent_prompt(userInfo: UserInfo) {
   Hello! I'll help you get your domain.\n Let's start by checking your ENS domain  {ENS_DOMAIN}. Give me a moment.\n/check  {ENS_DOMAIN}
 
 4. If the ENS domain is available,
-  Looks like  {ENS_DOMAIN} is available! Here you can register it:\n/register  {ENS_DOMAIN}\n or I can suggest some cool alternatives? Le me know!
+  Looks like  {ENS_DOMAIN} is available! Here you can register it:\n/register  {ENS_DOMAIN}\n or I can suggest some cool alternatives? Let me know!
 
 5. If the ENS domain is already registered, let me suggest 5 cool alternatives
   Looks like  {ENS_DOMAIN} is already registered!\n What about these cool alternatives?\n/cool  {ENS_DOMAIN}
@@ -53,7 +53,7 @@ export async function agent_prompt(userInfo: UserInfo) {
 
 ## Most common bugs
 
-1. Some times you will say something like: "Looks like vitalik.eth is registered! What about these cool alternatives?"
+1. Sometimes you will say something like: "Looks like vitalik.eth is registered! What about these cool alternatives?"
   But you forgot to add the command at the end of the message.
   You should have said something like: "Looks like vitalik.eth is registered! What about these cool alternatives?\n/cool vitalik.eth
 `;


### PR DESCRIPTION
1. In packages/docs/pages/middleware/gpt-sdk:
 - commes → comes
Reason: Typo fix
 - Dont → Don't
Reason: Missing apostrophe

2. In packages/docs/pages/skills/parsing.mdx:
  - skill → skills
Reason: Plural form needed

3. In packages/docs/pages/templates/agent/prompt.mdx:
 -  Le me know → Let me know
Reason: Typo fix
  - Some times → Sometimes
Reason: Correct word form


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a structured memory management system for chat interactions, enhancing chat history management.
  
- **Bug Fixes**
	- Corrected grammatical errors in documentation for improved clarity.
  
- **Documentation**
	- Minor textual adjustments made to clarify the definition of skills in the parsing documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->